### PR TITLE
Don't use ember-getowner-polyfill if we're supporting >2.3.

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
     "dependency injection"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6",
-    "ember-getowner-polyfill": "^1.0.1"
+    "ember-cli-babel": "^5.1.6"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/test-support/ember-test-component/index.js
+++ b/test-support/ember-test-component/index.js
@@ -1,7 +1,6 @@
 import Ember from 'ember';
-import getOwner from 'ember-getowner-polyfill';
 
-const { Component } = Ember;
+const { Component, getOwner } = Ember;
 const assign = Ember.assign || Ember.merge;
 
 export function registerTestComponent(context, opts = {}) {


### PR DESCRIPTION
The readme clearly states that it’s compatible with 2.4 LTS and up only.

So I think the `ember-getowner-polyfill` can be safely removed.

This gets rid of the annoying deprecation: `DEPRECATION: ember-getowner-polyfill is now a true polyfill.`

I’ve updated the package and tests are passing.