### PR TITLE
Make compatible with ember-qunit@3.0.0-beta.2 series.

### DIFF
--- a/test-support/ember-test-component/index.js
+++ b/test-support/ember-test-component/index.js
@@ -4,7 +4,7 @@ const { Component, getOwner } = Ember;
 const assign = Ember.assign || Ember.merge;
 
 export function registerTestComponent(context, opts = {}) {
-  let owner = getOwner(context);
+  let owner = context.owner || getOwner(context);
   let options = assign({ tagName: 'dummy' }, opts);
   let TestComponent = Component.extend(options);
 
@@ -13,7 +13,7 @@ export function registerTestComponent(context, opts = {}) {
 }
 
 export function unregisterTestComponent(context) {
-  let owner = getOwner(context);
+  let owner = context.owner || getOwner(context);
 
   if (owner.resolveRegistration('component:test-component')) {
     owner.unregister('component:test-component');


### PR DESCRIPTION
In the newer ember-qunit API the owner for the test environment is located at `this.owner` (and `getOwner(this)` returns undefined).

