### PR TITLE
update ember-cli-babl to 6.x version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,6 @@
 {
   "name": "ember-test-component",
   "dependencies": {
-    "ember": "~2.7.0",
-    "ember-cli-shims": "0.1.1",
     "ember-qunit-notifications": "0.1.0"
   }
 }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,10 +2,42 @@
 module.exports = {
   scenarios: [
     {
-      name: 'ember-lts',
+      name: 'ember-lts-2.4',
       bower: {
         dependencies: {
           'ember': '~2.4.0'
+        }
+      }
+    },
+    {
+      name: 'ember-lts-2.12',
+      npm: {
+        devDependencies: {
+          'ember-source': '~2.12.0'
+        }
+      }
+    },
+    {
+      name: 'ember-lts-2.16',
+      npm: {
+        devDependencies: {
+          'ember-source': '~2.16.0'
+        }
+      }
+    },
+    {
+      name: 'ember-lts-2.18',
+      npm: {
+        devDependencies: {
+          'ember-source': '~2.18.0'
+        }
+      }
+    },
+    {
+      name: 'ember-lts-3.4',
+      npm: {
+        devDependencies: {
+          'ember-source': '~3.4.0'
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -14,31 +14,30 @@
   "repository": "https://github.com/poteto/ember-test-component",
   "bugs": "https://github.com/poteto/ember-test-component/issues",
   "homepage": "https://github.com/poteto/ember-test-component",
-  "engines": {
-    "node": ">= 0.10.0"
-  },
   "author": "Lauren Tan <arr@sugarpirate.com>",
   "license": "MIT",
   "devDependencies": {
-    "broccoli-asset-rev": "^2.4.5",
-    "ember-ajax": "2.4.1",
-    "ember-cli": "2.7.0",
-    "ember-cli-app-version": "^1.0.0",
-    "ember-cli-dependency-checker": "^1.3.0",
-    "ember-cli-htmlbars": "^1.0.3",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.3",
-    "ember-cli-inject-live-reload": "^1.4.0",
+    "broccoli-asset-rev": "^3.0.0",
+    "ember-cli": "~3.4.3",
+    "ember-cli-app-version": "^3.2.0",
+    "ember-cli-dependency-checker": "^3.0.0",
+    "ember-cli-htmlbars": "^3.0.1",
+    "ember-cli-htmlbars-inline-precompile": "^1.0.4",
+    "ember-cli-inject-live-reload": "^1.8.2",
     "ember-cli-jshint": "^1.0.0",
-    "ember-cli-qunit": "^2.2.1",
-    "ember-cli-release": "^0.2.9",
+    "ember-cli-qunit": "^4.4.0",
+    "ember-cli-release": "^1.0.0-beta.2",
+    "ember-cli-shims": "^1.2.0",
     "ember-cli-sri": "^2.1.0",
-    "ember-cli-test-loader": "^1.1.0",
-    "ember-cli-uglify": "^1.2.0",
-    "ember-disable-prototype-extensions": "^1.1.0",
-    "ember-export-application-global": "^1.0.5",
-    "ember-load-initializers": "^0.5.1",
-    "ember-resolver": "^2.0.3",
-    "loader.js": "^4.0.1"
+    "ember-cli-test-loader": "^2.2.0",
+    "ember-cli-uglify": "^2.1.0",
+    "ember-disable-prototype-extensions": "^1.1.2",
+    "ember-export-application-global": "^2.0.0",
+    "ember-load-initializers": "^1.1.0",
+    "ember-resolver": "^4.0.0",
+    "ember-source": "~3.4.5",
+    "ember-try": "^1.1.0",
+    "loader.js": "^4.7.0"
   },
   "keywords": [
     "ember-addon",
@@ -46,9 +45,12 @@
     "dependency injection"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6"
+    "ember-cli-babel": "^7.1.2"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"
+  },
+  "engines": {
+    "node": "6.* || 8.* || >= 10.*"
   }
 }


### PR DESCRIPTION
* [x] updates ember try config to test against latest LTS releases
* [x] closes https://github.com/poteto/ember-test-component/issues/10